### PR TITLE
Bump Django from 3.2.16 to < 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.2
+[Full Changelog](https://github.com/uktrade/great-components/pull/10)
+### Implemented enhancements
+- KLS-392 - Bump Django from 3.2.16 to < 4.0.0
+
 ## 2.1.1
 [Full Changelog](https://github.com/uktrade/great-components/pull/10)
 ### Implemented enhancements

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=1.11,<4.0.0",
+        "django>=3.2.18,<4.0.0",
         "beautifulsoup4>=4.6.0,<5.0.0",
         "directory-constants>=20.3.0,<23.0.0",
         "jsonschema>=3.0.1,<4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.1.1",
+    version="2.1.2",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=1.11,<=3.2.16",
+        "django>=1.11,<4.0.0",
         "beautifulsoup4>=4.6.0,<5.0.0",
         "directory-constants>=20.3.0,<23.0.0",
         "jsonschema>=3.0.1,<4.0.0",


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.

