### PR TITLE
Allowing use of directory constants 23.0.0 or less

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "django>=3.2.18,<4.0.0",
         "beautifulsoup4>=4.6.0,<5.0.0",
-        "directory-constants>=20.3.0,<23.0.0",
+        "directory-constants>=20.3.0,<=23.0.0",
         "jsonschema>=3.0.1,<4.0.0",
     ],
     extras_require={


### PR DESCRIPTION
Update great-components to use newer version of directory constants 

 - [ ] Changelog entry added.
