### PR TITLE
Bump django support to 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0
+### Implemented enhancements
+[Full Changelog] ()
+- KLS-569 - Bump Django from 3.5.0 to 4.2.1
+
 ## 2.1.3
 ### Implemented enhancements
 [Full Changelog] (https://github.com/uktrade/great-components/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.0
 ### Implemented enhancements
-[Full Changelog] ()
+[Full Changelog] (https://github.com/uktrade/great-components/pull/14)
 - KLS-569 - Bump Django from 3.5.0 to 4.2.1
 
 ## 2.1.3

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.1.3",
+    version="2.2.0",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=3.2.18,<4.0.0",
+        "django>=3.2.18,<=4.2.1",
         "beautifulsoup4>=4.6.0,<5.0.0",
         "directory-constants>=20.3.0,<23.0.0",
         "jsonschema>=3.0.1,<4.0.0",
@@ -62,7 +62,7 @@ setup(
             "lorem==0.1.1",
             "django-environ==0.4.5",
             "gunicorn==19.5.0",
-            "whitenoise==3.3.1",
+            "whitenoise==6.4.0",
             "django-pygments==0.3.0",
         ],
         "janitor": [
@@ -78,6 +78,7 @@ setup(
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.
