### PR TITLE
Bump Jquery to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.1
+### Implemented enhancements
+[Full Changelog] ()
+- KLS-1009 - Upgrade JQuery to 3.5.0
+
 ## 2.3.0
 ### Implemented enhancements
 [Full Changelog] (https://github.com/uktrade/great-components/pull/20)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.3.0",
+    version="2.3.1",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",


### PR DESCRIPTION
bump jquery to 3.5.0

To do (delete all that do not apply):

 - [ ] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 
