### PR TITLE
KLS:1610 Add referer url to track the previous url

### DIFF
--- a/great_components/mixins.py
+++ b/great_components/mixins.py
@@ -64,12 +64,14 @@ class GA360Mixin:
         self.ga360_payload = {}
         super().__init__(*args, **kwargs)
 
-    def set_ga360_payload(self, page_id, business_unit, site_section, site_subsection=None):
+    def set_ga360_payload(self, page_id, business_unit, site_section, site_subsection=None, referer_url=None):
         self.ga360_payload['page_id'] = page_id
         self.ga360_payload['business_unit'] = business_unit
         self.ga360_payload['site_section'] = site_section
         if site_subsection:
             self.ga360_payload['site_subsection'] = site_subsection
+        if referer_url:
+            self.ga360_payload['referer_url'] = referer_url
 
     def get_context_data(self, *args, **kwargs):
         user = helpers.get_user(self.request)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.4.0",
+    version="2.5.0",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -98,7 +98,8 @@ def test_ga360_mixin_for_logged_in_user_old_style(rf):
                 page_id='TestPageId',
                 business_unit='Test App',
                 site_section='Test Section',
-                site_subsection='Test Page'
+                site_subsection='Test Page',
+                referer_url='http:anyurl.com'
             )
 
     request = rf.get('/')
@@ -117,6 +118,7 @@ def test_ga360_mixin_for_logged_in_user_old_style(rf):
     assert ga360_data['business_unit'] == 'Test App'
     assert ga360_data['site_section'] == 'Test Section'
     assert ga360_data['site_subsection'] == 'Test Page'
+    assert ga360_data['referer_url'] == 'http:anyurl.com'
     assert ga360_data['user_id'] == 'a9a8f733-6bbb-4dca-a682-e8a0a18439e9'
     assert ga360_data['login_status'] is True
     assert ga360_data['site_language'] == 'de'
@@ -132,7 +134,8 @@ def test_ga360_mixin_for_logged_in_user(rf):
                 page_id='TestPageId',
                 business_unit='Test App',
                 site_section='Test Section',
-                site_subsection='Test Page'
+                site_subsection='Test Page',
+                referer_url='http:anyurl.com'
             )
 
     request = rf.get('/')
@@ -152,6 +155,7 @@ def test_ga360_mixin_for_logged_in_user(rf):
     assert ga360_data['business_unit'] == 'Test App'
     assert ga360_data['site_section'] == 'Test Section'
     assert ga360_data['site_subsection'] == 'Test Page'
+    assert ga360_data['referer_url'] == 'http:anyurl.com'
     assert ga360_data['user_id'] == 'a9a8f733-6bbb-4dca-a682-e8a0a18439e9'
     assert ga360_data['login_status'] is True
     assert ga360_data['site_language'] == 'de'
@@ -167,7 +171,8 @@ def test_ga360_mixin_for_admin_user_old_style(rf):
                 page_id='TestPageId',
                 business_unit='Test App',
                 site_section='Test Section',
-                site_subsection='Test Page'
+                site_subsection='Test Page',
+                referer_url='http:anyurl.com'
             )
 
     request = rf.get('/')
@@ -196,7 +201,8 @@ def test_ga360_mixin_for_anonymous_user_old_style(rf):
                 page_id='TestPageId',
                 business_unit='Test App',
                 site_section='Test Section',
-                site_subsection='Test Page'
+                site_subsection='Test Page',
+                referer_url='http:anyurl.com'
             )
 
     request = rf.get('/')
@@ -221,7 +227,8 @@ def test_ga360_mixin_for_anonymous_user(rf):
                 page_id='TestPageId',
                 business_unit='Test App',
                 site_section='Test Section',
-                site_subsection='Test Page'
+                site_subsection='Test Page',
+                referer_url='http:anyurl.com'
             )
 
     request = rf.get('/')

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -99,7 +99,7 @@ def test_ga360_mixin_for_logged_in_user_old_style(rf):
                 business_unit='Test App',
                 site_section='Test Section',
                 site_subsection='Test Page',
-                referer_url='http:anyurl.com'
+                referer_url='http://anyurl.com'
             )
 
     request = rf.get('/')
@@ -118,7 +118,7 @@ def test_ga360_mixin_for_logged_in_user_old_style(rf):
     assert ga360_data['business_unit'] == 'Test App'
     assert ga360_data['site_section'] == 'Test Section'
     assert ga360_data['site_subsection'] == 'Test Page'
-    assert ga360_data['referer_url'] == 'http:anyurl.com'
+    assert ga360_data['referer_url'] == 'http://anyurl.com'
     assert ga360_data['user_id'] == 'a9a8f733-6bbb-4dca-a682-e8a0a18439e9'
     assert ga360_data['login_status'] is True
     assert ga360_data['site_language'] == 'de'
@@ -135,7 +135,7 @@ def test_ga360_mixin_for_logged_in_user(rf):
                 business_unit='Test App',
                 site_section='Test Section',
                 site_subsection='Test Page',
-                referer_url='http:anyurl.com'
+                referer_url='http://anyurl.com'
             )
 
     request = rf.get('/')
@@ -155,7 +155,7 @@ def test_ga360_mixin_for_logged_in_user(rf):
     assert ga360_data['business_unit'] == 'Test App'
     assert ga360_data['site_section'] == 'Test Section'
     assert ga360_data['site_subsection'] == 'Test Page'
-    assert ga360_data['referer_url'] == 'http:anyurl.com'
+    assert ga360_data['referer_url'] == 'http://anyurl.com'
     assert ga360_data['user_id'] == 'a9a8f733-6bbb-4dca-a682-e8a0a18439e9'
     assert ga360_data['login_status'] is True
     assert ga360_data['site_language'] == 'de'
@@ -172,7 +172,7 @@ def test_ga360_mixin_for_admin_user_old_style(rf):
                 business_unit='Test App',
                 site_section='Test Section',
                 site_subsection='Test Page',
-                referer_url='http:anyurl.com'
+                referer_url='http://anyurl.com'
             )
 
     request = rf.get('/')
@@ -202,7 +202,7 @@ def test_ga360_mixin_for_anonymous_user_old_style(rf):
                 business_unit='Test App',
                 site_section='Test Section',
                 site_subsection='Test Page',
-                referer_url='http:anyurl.com'
+                referer_url='http://anyurl.com'
             )
 
     request = rf.get('/')
@@ -228,7 +228,7 @@ def test_ga360_mixin_for_anonymous_user(rf):
                 business_unit='Test App',
                 site_section='Test Section',
                 site_subsection='Test Page',
-                referer_url='http:anyurl.com'
+                referer_url='http://anyurl.com'
             )
 
     request = rf.get('/')


### PR DESCRIPTION
Add a new referer url to GA to track the previous url the user is coming from . 
