### PR TITLE
Set Django to 4.2.7 Minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.2
+### Implemented enhancements
+[Full Changelog] () (23-01-2024)
+- KLS-1825 - Set Django minimum to 4.2.7
+
 ## 2.3.0
 ### Implemented enhancements
 [Full Changelog] (https://github.com/uktrade/great-components/pull/20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.2
 ### Implemented enhancements
-[Full Changelog] () (23-01-2024)
+[Full Changelog] (https://github.com/uktrade/great-components/pull/26) (23-01-2024)
 - KLS-1825 - Set Django minimum to 4.2.7
 
 ## 2.3.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.5.1",
+    version="2.5.2",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",
@@ -14,9 +14,9 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=3.2.18,<=4.2",
+        "django>=4.2.7,<4.8",
         "beautifulsoup4>=4.6.0,<5.0.0",
-        "directory-constants>=20.3.0,<=24.0",
+        "directory-constants>=24.1.0,<=25.0",
         "jsonschema>=3.0.1,<4.0.0",
     ],
     extras_require={


### PR DESCRIPTION
Set Django to 4.2.7 Minimum

 - [x] Changelog entry added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.

