### PR TITLE
Feature/kls 1882 remove current page from breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.3
 ### Implemented enhancements
-[Full Changelog] () (24-01-2024)
+[Full Changelog] (https://github.com/uktrade/great-components/pull/27) (24-01-2024)
 - KLS-1882 - Dont add the current page to the Breadcrumbs class
 
 ## 2.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.3
+### Implemented enhancements
+[Full Changelog] () (24-01-2024)
+- KLS-1882 - Dont add the current page to the Breadcrumbs class
+
 ## 2.5.2
 ### Implemented enhancements
 [Full Changelog] (https://github.com/uktrade/great-components/pull/26) (23-01-2024)

--- a/great_components/templatetags/great_components.py
+++ b/great_components/templatetags/great_components.py
@@ -293,10 +293,11 @@ class Breadcrumbs(template.Node):
             output_soup.find('ol').append(element)
 
         # adding the current page
-        current = template.Variable(self.bit).resolve(context)
-        output_soup.find('ol').append(
-            f'<li aria-current="page"><span>{current}</span></li>'
-        )
+        # DEU 24/1/2024 KLS-1882 - dont add current page to Breadcrumb
+        # current = template.Variable(self.bit).resolve(context)
+        # output_soup.find('ol').append(
+        #     f'<li aria-current="page"><span>{current}</span></li>'
+        # )
         return output_soup.decode(formatter=None)
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "django>=4.2.7,<4.2.8",
         "beautifulsoup4>=4.6.0,<5.0.0",
-        "directory-constants>=24.1.0,<=25.0",
+        "directory-constants>=24.1.0,<25.0",
         "jsonschema>=3.0.1,<4.0.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.5.2",
+    version="2.5.3",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=4.2.7,<4.8",
+        "django>=4.2.7,<4.2.8",
         "beautifulsoup4>=4.6.0,<5.0.0",
         "directory-constants>=24.1.0,<=25.0",
         "jsonschema>=3.0.1,<4.0.0",

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -679,10 +679,10 @@ def test_breadcrumbs():
         '<li><a href="/foo"></a></li>'
         '<li><a href="/bar"></a></li>'
         '<li><a href="/baz"></a></li>'
-        '<li aria-current="page"><span>Current Page</span></li>'
         '</ol>'
         '</nav>'
     )
+    
     assert rendered_html.replace('\n', '') == expected_html
 
 
@@ -710,7 +710,6 @@ def test_breadcrumbs_context_variables():
         '<li><a href="/foo">Foo</a></li>'
         '<li><a href="/bar">Bar</a></li>'
         '<li><a href="/baz">Baz</a></li>'
-        '<li aria-current="page"><span>Current Page</span></li>'
         '</ol>'
         '</nav>'
     )

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -682,7 +682,6 @@ def test_breadcrumbs():
         '</ol>'
         '</nav>'
     )
-    
     assert rendered_html.replace('\n', '') == expected_html
 
 


### PR DESCRIPTION
Feature/kls 1882 remove current page from breadcrumbs

If current page is passed to Breadcrumb is it ignored

 - [ ] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 