### PR TITLE
KLS-1795 - add block for inline feedback inside body tags

### DIFF
--- a/great_components/templates/great_components/base.html
+++ b/great_components/templates/great_components/base.html
@@ -113,6 +113,9 @@
             </main>
         {% endblock %}
 
+        {% block body_inline_feedback %}
+        {% endblock %}
+
         {% block body_footer %}
             {% include 'great_components/header_footer/domestic_footer.html' %}
         {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="great_components",
-    version="2.5.3",
+    version="2.6.0",
     url="https://github.com/uktrade/great-components",
     license="MIT",
     author="DIT",


### PR DESCRIPTION
This PR adds a block to contain inline feedback. The addition is necessary to enable content to be added within body tags that would not be considered part of main content.
